### PR TITLE
Fix "code" segment shown on new line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -296,6 +296,7 @@ Table.prototype.toString = function (){
 
         // check if the symbol after wrap_value is delimiter;
         if (isDelimiter(content[wrap_value])) {
+          wrap_value = get_index_after_code(content, wrap_value);
           current_line = content.substring(0, wrap_value).trim();
           remaining = content.substring(wrap_value).trim();
         } else {
@@ -304,11 +305,11 @@ Table.prototype.toString = function (){
             return isDelimiter(chr);
           });
 
-          if(index === -1) {
+          if(index <= 0) {
             //no delimiter, lets just split the word
             index = wrap_value;
           }
-
+          index = get_index_after_code(content, index);
           current_line = content.substring(0, index).trim();
           remaining = content.substring(index).trim();
         }
@@ -329,6 +330,27 @@ Table.prototype.toString = function (){
     // If there's no content or it's width is below wrap_line_length, return the value
     return current_line;
   };
+  
+  /**
+  * Gets the index on which the text should be splitted. In case the symbol on the index 
+  * where we'll split is part of "code" segment, make sure to include the whole segment.
+  * @param {string} content The text to be split.
+  * @param {number} index The index where the string will be splitted.
+  * @return Number The index on which we have to split the string.
+  */
+  function get_index_after_code(content, index) {
+    var temp = content.substring(0, index + 10);
+    var code_match = temp.match(/[\s\S]*(\u001b\[(?:\d*;){0,5}\d*m)/);
+    if(code_match) {
+      var code = code_match[1];
+      var indexOfCode = temp.indexOf(code);
+      if(indexOfCode <= index && index <= indexOfCode + code.length) {
+        index = indexOfCode + code.length;
+      }
+    }
+
+    return index;
+  }
 
   function generateRow (items, style) {
     var cells = []


### PR DESCRIPTION
In cases when we want to split the text inside column of cli-table, we try to find out the first delimiter. As this delimiter may be part of "code" segment, we must be sure to include the whole segment on the current line.

Also fix the case when the text starts with delimiter and should be splitted, for example '-configuration'. The code finds the last delimiter, which is on index 0 and for the next iteration it uses `remaining = content.substring(index).trim()`, which leads to infinite loop.
