### PR TITLE
Fix narrow columns issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -244,6 +244,17 @@ Table.prototype.toString = function (){
   * @return number value indicating sum of all code symbols in the text, that we'll use for current line.
   */
   function extendWrapLine(content, wrap_line_length) {
+    var hasColorization = content.match(/(\u001b\[(?:\d*;){0,5}\d*m)/g);
+     if(!hasColorization) {
+      return 0;
+     }
+
+    var colorizationSymbols = hasColorization.join("").length;
+
+    if((content.length - colorizationSymbols) <= wrap_line_length){
+      return colorizationSymbols;
+    }
+    
     var textToTake = content.substring(0, wrap_line_length);
     var sumOfSymbolsToAdd = 0; 
     var mtch = [];


### PR DESCRIPTION
When we have narrow columns (below or equal to 2px) and they are colorized, the cli-table goes in endless loop when trying to beautify the string. Make sure to return the lenght of all colorization symbols in extendWrapLine when the whole content can be shown in the current wrap_line_length.
