### PR TITLE
Fix issue with padding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -295,9 +295,9 @@ Table.prototype.toString = function (){
   * @return String splitted on several lines.
   */
   function beautify_string(content, wrap_line_length) {
-    // - 2 for padding, borders, etc. 
-    var wrap_value = (wrap_line_length - 2) || 250;
-    var symbolsToAdd =  extendWrapLine(content, wrap_line_length);
+    var padding = (style['padding-left'] || 0) + (style['padding-right'] || 0);
+    var wrap_value = wrap_line_length > padding ? wrap_line_length - padding : 250;
+    var symbolsToAdd =  extendWrapLine(content, wrap_value);
     wrap_value += symbolsToAdd;
     var current_line = content || "";
     if (content) {


### PR DESCRIPTION
In case there's padding on each cell, in some cases cli-table trims the text in the cell (replacing the parts that could not be shown with ....). This is due to incorrect value passed to extendWrapLine method, where the padding of the cell is not taken into account. Make sure correct padding is used.

Fixes http://teampulse.telerik.com/view#item/291100
