### PR TITLE
Fix table rendering

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ Table.prototype.__defineGetter__('width', function (){
  * @api public
  */
 
-Table.prototype.render = 
+Table.prototype.render =
 Table.prototype.toString = function (){
   var ret = ''
     , options = this.options
@@ -87,9 +87,9 @@ Table.prototype.toString = function (){
     , colWidths = options.colWidths || new Array(this.head.length)
     , totalWidth = 0
     , terminal_width = process.stdout.columns;
-  
+
   // The minimum width of a column when terminal width is above table's required one.
-  // NOTE: Columns which have required width below min_column_width will be renedered with their required width.  
+  // NOTE: Columns which have required width below min_column_width will be renedered with their required width.
   var min_column_width = options.min_column_width || 15 ;
   if (!head.length && !this.length) return '';
 
@@ -132,7 +132,7 @@ Table.prototype.toString = function (){
       var remaining_terminal_width = terminal_width - (colWidths.length * 2);
       var remaining_required_width = required_width;
       var calculated_values = [];
-      
+
       var recalculate_col_widths = function() {
         calculated_values.forEach(function(calc_value) {
           var value = Math.floor((calc_value.original_value/remaining_required_width)*remaining_terminal_width);
@@ -158,17 +158,17 @@ Table.prototype.toString = function (){
             recalculate_col_widths();
             return ceil;
         }
-        
+
         var calculated_value = Math.floor((col/remaining_required_width)*remaining_terminal_width);
         if(calculated_value >= min_column_width) {
             calculated_values.push({original_value: col, ind: index});
             return calculated_value;
-        } 
-        
+        }
+
         remaining_terminal_width -= min_column_width;
         remaining_required_width -= col;
         recalculate_col_widths();
-        
+
         return min_column_width;
       });
     }
@@ -177,7 +177,7 @@ Table.prototype.toString = function (){
     if(calc_req_width > terminal_width) {
       console.warn("Calculated width "+ calc_req_width +" is above terminal width: " + terminal_width + ". You can try using smaller value for min_column_width. Current value is: " + min_column_width);
     }
-    
+
     this.options.colWidths = colWidths;
   };
 
@@ -254,9 +254,9 @@ Table.prototype.toString = function (){
     if((content.length - colorizationSymbols) <= wrap_line_length){
       return colorizationSymbols;
     }
-    
+
     var textToTake = content.substring(0, wrap_line_length);
-    var sumOfSymbolsToAdd = 0; 
+    var sumOfSymbolsToAdd = 0;
     var mtch = [];
     while(mtch = textToTake.match(/(\u001b\[(?:\d*;){0,5}\d*m)/)) {
       sumOfSymbolsToAdd += mtch[1].length;
@@ -341,9 +341,9 @@ Table.prototype.toString = function (){
     // If there's no content or it's width is below wrap_line_length, return the value
     return current_line;
   };
-  
+
   /**
-  * Gets the index on which the text should be splitted. In case the symbol on the index 
+  * Gets the index on which the text should be splitted. In case the symbol on the index
   * where we'll split is part of "code" segment, make sure to include the whole segment.
   * @param {string} content The text to be split.
   * @param {number} index The index where the string will be splitted.
@@ -383,7 +383,7 @@ Table.prototype.toString = function (){
 
     // transform array of item strings into structure of cells
     items.forEach(function (item, i) {
-      var contents = beautify_string(item.toString(), this.options.colWidths[i])
+      var contents = beautify_string((item || "").toString().replace('\r', ''), this.options.colWidths[i])
         .split("\n")
         .reduce(function (memo, l) {
           memo.push(string(l, i));


### PR DESCRIPTION
Remove `\r` as breaking the table.
Allow passing null as content for cell.
